### PR TITLE
minor, but anoing floating point error

### DIFF
--- a/paymill_payment_cc.html
+++ b/paymill_payment_cc.html
@@ -117,7 +117,7 @@
             }
 
             var params = {
-                amount_int:     parseInt($('.amount').val().replace(/[\.,]/, '.') * 100),  // E.g. "15" for 0.15 Eur
+                amount_int:     Math.round($('.amount').val().replace(/[\.,]/, '.') * 100),  // E.g. "15" for 0.15 Eur
                 currency:       $('.currency').val(),    // ISO 4217 e.g. "EUR"
                 number:         $('.card-number').val(),
                 exp_month:      expiry[0],


### PR DESCRIPTION
Example:

> parseInt('37.8' \* 100)
> < 3779
> 
> Math.round('37.8' \* 100)
> < 3780
